### PR TITLE
fix syntax warnings

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,2 @@
-AllCops:
-  Exclude:
-    - 'bin/spring'
-
 Metrics/LineLength:
   Max: 120

--- a/bin/spring
+++ b/bin/spring
@@ -7,7 +7,8 @@ unless defined?(Spring)
   require "rubygems"
   require "bundler"
 
-  if match = Bundler.default_lockfile.read.match(/^GEM$.*?^    (?:  )*spring \((.*?)\)$.*?^$/m)
+  match = Bundler.default_lockfile.read.match(/^GEM$.*?^    (?:  )*spring \((.*?)\)$.*?^$/m)
+  if !match.nil?
     Gem.paths = { "GEM_PATH" => [Bundler.bundle_path.to_s, *Gem.path].uniq }
     gem "spring", match[1]
     require "spring/binstub"


### PR DESCRIPTION
For some reason circle will run the cops on many more files if you exclude a single file.